### PR TITLE
fix: don't list users twice in `intra online`

### DIFF
--- a/src/modules/intra42/commands.js
+++ b/src/modules/intra42/commands.js
@@ -128,7 +128,8 @@ export function register() {
         client
           .getAll(`/campus/${process.env.INTRA42_CAMPUS_ID}/locations`, {
             filter: {
-              active: true
+              active: true,
+              primary: true,
             },
             per_page: 100
           })


### PR DESCRIPTION
The api appears to sometimes return what I would call zombie logins where one user appears to be logged in into multiple iMacs. Of these logins, the correct one seems to always have `primary: true` while the incorrect ones seem to always have `primary: false`.

Example valid location:

```
{ end_at: null,
  id: 8469633,
  begin_at: '2019-04-25T17:27:06.000Z',
  primary: true,
  host: 'f0r3s12.codam.nl',
  campus_id: 14,
  user:
   { id: 46501,
     login: 'bprado',
     url: 'https://api.intra.42.fr/v2/users/bprado' } }
```

Example invalid location:

```
{ end_at: null,
  id: 8469861,
  begin_at: '2019-04-25T18:09:25.000Z',
  primary: false,
  host: 'f0r2s13.codam.nl',
  campus_id: 14,
  user:
   { id: 46501,
     login: 'bprado',
     url: 'https://api.intra.42.fr/v2/users/bprado' } }
```

Let's filter on the primary locations as not to double count a user.

---

**Warning:** I did _not_ test this, since I do not have a development setup. This fix was adapted from [nloomans/codam-mapper](https://github.com/nloomans/codam-mapper).